### PR TITLE
Configure MLM income and referral system

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,446 @@
+-- Enable UUID extension
+create extension if not exists "uuid-ossp";
+
+-- Create profiles table (extends Supabase auth.users)
+create table if not exists profiles (
+  id uuid references auth.users on delete cascade primary key,
+  gpk_id text unique not null,
+  name text not null,
+  email text unique not null,
+  phone text,
+  referral_code text unique not null,
+  sponsor_id uuid references profiles(id) on delete set null,
+  wallet_address text,
+  transaction_password text,
+  current_package text default 'none',
+  is_active boolean default true,
+  is_admin boolean default false,
+  join_date timestamp default now(),
+  total_earnings numeric default 0,
+  wallet_balance numeric default 0,
+  team_size integer default 0,
+  direct_referrals integer default 0,
+  created_at timestamp default now(),
+  updated_at timestamp default now()
+);
+
+-- Admin configuration table
+create table if not exists admin_config (
+  id serial primary key,
+  direct_referral_percent numeric not null default 25,
+  level_income_percents numeric[] default array[1,1,1,1,1,1,1,2,3,3],
+  global_royalty_percent numeric default 15,
+  global_royalty_cycle_days integer default 90,
+  deposit_wallet_address text,
+  minimum_withdrawal numeric default 100,
+  minimum_deposit numeric default 100,
+  withdrawal_fee_percent numeric default 5,
+  deposit_fee_percent numeric default 2,
+  created_at timestamp default now(),
+  updated_at timestamp default now()
+);
+
+-- Seed default admin config
+insert into admin_config (direct_referral_percent) values (25)
+on conflict do nothing;
+
+-- Packages table
+create table if not exists packages (
+  id text primary key,
+  name text not null,
+  price numeric not null,
+  order_index integer not null,
+  global_royalty_eligible boolean default false,
+  global_royalty_share_percent numeric default 0,
+  description text,
+  benefits text[],
+  is_active boolean default true,
+  created_at timestamp default now(),
+  updated_at timestamp default now()
+);
+
+-- Insert GrowwPark packages
+insert into packages (id, name, price, order_index, global_royalty_eligible, global_royalty_share_percent, description, benefits, is_active) values
+('starter', 'Starter', 2500, 1, false, 0, 'Entry level package to get started', array['Basic support', 'Access to community'], true),
+('silver', 'Silver', 9500, 2, true, 2, 'Silver package with global royalty eligibility', array['Priority support', 'Training materials', '2% Global royalty share'], true),
+('gold', 'Gold', 25000, 3, true, 3, 'Gold package with enhanced benefits', array['Premium support', 'Advanced training', '3% Global royalty share'], true),
+('platinum', 'Platinum', 95000, 4, true, 4, 'Platinum package for serious builders', array['VIP support', 'Exclusive events', '4% Global royalty share'], true),
+('diamond', 'Diamond', 250000, 5, true, 6, 'Ultimate Diamond package', array['Personal mentor', 'Diamond events', '6% Global royalty share'], true)
+on conflict (id) do update set
+name = excluded.name,
+price = excluded.price,
+order_index = excluded.order_index,
+global_royalty_eligible = excluded.global_royalty_eligible,
+global_royalty_share_percent = excluded.global_royalty_share_percent,
+description = excluded.description,
+benefits = excluded.benefits,
+updated_at = now();
+
+-- User packages table (track user's package purchases)
+create table if not exists user_packages (
+  id uuid default uuid_generate_v4() primary key,
+  user_id uuid references profiles(id) on delete cascade,
+  package_id text references packages(id),
+  purchase_date timestamp default now(),
+  amount_paid numeric not null,
+  is_active boolean default true,
+  created_at timestamp default now(),
+  unique(user_id, package_id)
+);
+
+-- Incomes table
+create table if not exists incomes (
+  id uuid default uuid_generate_v4() primary key,
+  user_id uuid references profiles(id) on delete cascade,
+  from_user_id uuid references profiles(id) on delete set null,
+  amount numeric not null,
+  type text check (type in ('direct', 'level', 'global_royalty')),
+  level integer,
+  package_id text references packages(id),
+  description text,
+  date timestamp default now(),
+  created_at timestamp default now()
+);
+
+-- Referrals table
+create table if not exists referrals (
+  referrer_id uuid references profiles(id) on delete cascade,
+  referred_id uuid references profiles(id) on delete cascade,
+  referral_date timestamp default now(),
+  primary key (referrer_id, referred_id)
+);
+
+-- Level qualifications table (track which levels users have qualified for)
+create table if not exists level_qualifications (
+  id uuid default uuid_generate_v4() primary key,
+  user_id uuid references profiles(id) on delete cascade,
+  level integer not null,
+  qualified_at timestamp default now(),
+  team_size_at_qualification integer default 0,
+  unique(user_id, level)
+);
+
+-- Global royalty distributions table
+create table if not exists global_royalty_distributions (
+  id uuid default uuid_generate_v4() primary key,
+  cycle_start_date timestamp not null,
+  cycle_end_date timestamp not null,
+  total_pool_amount numeric not null,
+  total_eligible_users integer default 0,
+  distributed_amount numeric default 0,
+  status text default 'pending' check (status in ('pending', 'distributed', 'completed')),
+  created_at timestamp default now()
+);
+
+-- Global royalty payments table
+create table if not exists global_royalty_payments (
+  id uuid default uuid_generate_v4() primary key,
+  distribution_id uuid references global_royalty_distributions(id) on delete cascade,
+  user_id uuid references profiles(id) on delete cascade,
+  package_id text references packages(id),
+  share_percent numeric not null,
+  amount numeric not null,
+  created_at timestamp default now()
+);
+
+-- Transactions table
+create table if not exists transactions (
+  id uuid default uuid_generate_v4() primary key,
+  user_id uuid references profiles(id) on delete cascade,
+  type text check (type in ('deposit', 'withdrawal', 'package_purchase', 'income_credit')),
+  amount numeric not null,
+  tx_hash text,
+  wallet_address text,
+  status text default 'pending' check (status in ('pending', 'verified', 'rejected', 'completed')),
+  admin_fee numeric default 0,
+  reference_id text,
+  package_id text references packages(id),
+  description text,
+  date timestamp default now(),
+  created_at timestamp default now(),
+  updated_at timestamp default now()
+);
+
+-- Create indexes for better performance
+create index if not exists idx_profiles_sponsor_id on profiles(sponsor_id);
+create index if not exists idx_profiles_referral_code on profiles(referral_code);
+create index if not exists idx_incomes_user_id on incomes(user_id);
+create index if not exists idx_incomes_from_user_id on incomes(from_user_id);
+create index if not exists idx_incomes_type on incomes(type);
+create index if not exists idx_transactions_user_id on transactions(user_id);
+create index if not exists idx_transactions_type on transactions(type);
+create index if not exists idx_user_packages_user_id on user_packages(user_id);
+create index if not exists idx_referrals_referrer_id on referrals(referrer_id);
+
+-- RLS (Row Level Security) policies
+alter table profiles enable row level security;
+alter table incomes enable row level security;
+alter table transactions enable row level security;
+alter table user_packages enable row level security;
+alter table referrals enable row level security;
+alter table level_qualifications enable row level security;
+alter table global_royalty_payments enable row level security;
+
+-- Profiles policies
+create policy "Users can view their own profile" on profiles for select using (auth.uid() = id);
+create policy "Users can update their own profile" on profiles for update using (auth.uid() = id);
+create policy "Users can view referral tree" on profiles for select using (
+  exists (
+    select 1 from profiles p where p.id = auth.uid() and p.is_admin = true
+  ) or 
+  sponsor_id = auth.uid() or 
+  id in (
+    select referred_id from referrals where referrer_id = auth.uid()
+  )
+);
+
+-- Incomes policies
+create policy "Users can view their own incomes" on incomes for select using (user_id = auth.uid());
+
+-- Transactions policies
+create policy "Users can view their own transactions" on transactions for select using (user_id = auth.uid());
+create policy "Users can insert their own transactions" on transactions for insert with check (user_id = auth.uid());
+
+-- User packages policies
+create policy "Users can view their own packages" on user_packages for select using (user_id = auth.uid());
+create policy "Users can insert their own packages" on user_packages for insert with check (user_id = auth.uid());
+
+-- Functions for MLM calculations
+create or replace function get_user_level_qualification(user_id uuid)
+returns integer as $$
+declare
+  direct_count integer;
+  max_level integer := 0;
+begin
+  -- Get direct referral count
+  select count(*) into direct_count
+  from referrals
+  where referrer_id = user_id;
+  
+  -- Calculate qualification level based on team size
+  if direct_count >= 5 then
+    -- Check each level requirement
+    for i in 1..10 loop
+      declare
+        required_team_size integer := power(5, i);
+        actual_team_size integer;
+      begin
+        -- Calculate actual team size at this level (simplified)
+        select count(*) into actual_team_size
+        from profiles
+        where sponsor_id = user_id;
+        
+        if actual_team_size >= required_team_size then
+          max_level := i;
+        else
+          exit;
+        end if;
+      end;
+    end loop;
+  end if;
+  
+  return max_level;
+end;
+$$ language plpgsql;
+
+-- Function to calculate and distribute level income
+create or replace function distribute_level_income(buyer_id uuid, package_price numeric)
+returns void as $$
+declare
+  current_user_id uuid := buyer_id;
+  level_count integer := 1;
+  level_percents numeric[] := array[1,1,1,1,1,1,1,2,3,3];
+  level_percent numeric;
+  income_amount numeric;
+begin
+  -- Traverse up the sponsor tree for 10 levels
+  while current_user_id is not null and level_count <= 10 loop
+    -- Get the sponsor
+    select sponsor_id into current_user_id
+    from profiles
+    where id = current_user_id;
+    
+    if current_user_id is not null then
+      -- Check if sponsor is qualified for this level
+      if get_user_level_qualification(current_user_id) >= level_count then
+        level_percent := level_percents[level_count];
+        income_amount := (package_price * level_percent / 100);
+        
+        -- Credit level income
+        insert into incomes (user_id, from_user_id, amount, type, level, package_id, description)
+        values (
+          current_user_id,
+          buyer_id,
+          income_amount,
+          'level',
+          level_count,
+          (select package_id from user_packages where user_id = buyer_id order by created_at desc limit 1),
+          format('Level %s income from %s', level_count, (select name from profiles where id = buyer_id))
+        );
+        
+        -- Update user's total earnings and wallet balance
+        update profiles
+        set total_earnings = total_earnings + income_amount,
+            wallet_balance = wallet_balance + income_amount,
+            updated_at = now()
+        where id = current_user_id;
+      end if;
+      
+      level_count := level_count + 1;
+    end if;
+  end loop;
+end;
+$$ language plpgsql;
+
+-- Function to handle package purchase and income distribution
+create or replace function handle_package_purchase(user_id uuid, package_id text, amount_paid numeric)
+returns void as $$
+declare
+  sponsor_id uuid;
+  direct_income_amount numeric;
+  config_direct_percent numeric;
+begin
+  -- Get admin config
+  select direct_referral_percent into config_direct_percent
+  from admin_config
+  limit 1;
+  
+  -- Get user's sponsor
+  select p.sponsor_id into sponsor_id
+  from profiles p
+  where p.id = user_id;
+  
+  -- Record package purchase
+  insert into user_packages (user_id, package_id, amount_paid)
+  values (user_id, package_id, amount_paid)
+  on conflict (user_id, package_id) do update set
+    amount_paid = excluded.amount_paid,
+    created_at = now();
+  
+  -- Update user's current package
+  update profiles
+  set current_package = package_id,
+      updated_at = now()
+  where id = user_id;
+  
+  -- Distribute direct referral income (only for first package purchase)
+  if sponsor_id is not null then
+    -- Check if this is the first package purchase by this user
+    if not exists (
+      select 1 from incomes 
+      where user_id = sponsor_id 
+      and from_user_id = user_id 
+      and type = 'direct'
+    ) then
+      direct_income_amount := (amount_paid * config_direct_percent / 100);
+      
+      -- Credit direct referral income
+      insert into incomes (user_id, from_user_id, amount, type, package_id, description)
+      values (
+        sponsor_id,
+        user_id,
+        direct_income_amount,
+        'direct',
+        package_id,
+        format('Direct referral income from %s', (select name from profiles where id = user_id))
+      );
+      
+      -- Update sponsor's earnings
+      update profiles
+      set total_earnings = total_earnings + direct_income_amount,
+          wallet_balance = wallet_balance + direct_income_amount,
+          updated_at = now()
+      where id = sponsor_id;
+    end if;
+  end if;
+  
+  -- Distribute level income
+  perform distribute_level_income(user_id, amount_paid);
+  
+  -- Record transaction
+  insert into transactions (user_id, type, amount, package_id, status, description)
+  values (
+    user_id,
+    'package_purchase',
+    amount_paid,
+    package_id,
+    'completed',
+    format('Purchase of %s package', (select name from packages where id = package_id))
+  );
+end;
+$$ language plpgsql;
+
+-- Trigger to update team size when referrals are added
+create or replace function update_team_sizes()
+returns trigger as $$
+begin
+  -- Update direct referrals count for the referrer
+  update profiles
+  set direct_referrals = direct_referrals + 1,
+      updated_at = now()
+  where id = new.referrer_id;
+  
+  -- Update team size for all uplines
+  with recursive upline_tree as (
+    select sponsor_id as user_id, 1 as level
+    from profiles
+    where id = new.referred_id
+    
+    union all
+    
+    select p.sponsor_id, ut.level + 1
+    from profiles p
+    join upline_tree ut on p.id = ut.user_id
+    where p.sponsor_id is not null and ut.level < 20
+  )
+  update profiles
+  set team_size = team_size + 1,
+      updated_at = now()
+  where id in (select user_id from upline_tree where user_id is not null);
+  
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trigger_update_team_sizes
+  after insert on referrals
+  for each row
+  execute function update_team_sizes();
+
+-- Function to generate unique referral code
+create or replace function generate_referral_code()
+returns text as $$
+declare
+  code text;
+  exists_check boolean;
+begin
+  loop
+    code := 'GPK' || lpad(floor(random() * 999999)::text, 6, '0');
+    
+    select exists(select 1 from profiles where referral_code = code) into exists_check;
+    
+    if not exists_check then
+      return code;
+    end if;
+  end loop;
+end;
+$$ language plpgsql;
+
+-- Function to generate unique GPK ID
+create or replace function generate_gpk_id()
+returns text as $$
+declare
+  gpk_id text;
+  exists_check boolean;
+begin
+  loop
+    gpk_id := 'GPK' || lpad(floor(random() * 9999999)::text, 7, '0');
+    
+    select exists(select 1 from profiles where gpk_id = gpk_id) into exists_check;
+    
+    if not exists_check then
+      return gpk_id;
+    end if;
+  end loop;
+end;
+$$ language plpgsql;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -9,48 +9,69 @@ if (!supabaseUrl || !supabaseAnonKey) {
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
-// Database types
+// Database types for the MLM system
 export interface Database {
   public: {
     Tables: {
-      users: {
+      profiles: {
         Row: {
           id: string;
           gpk_id: string;
           name: string;
           email: string;
-          phone: string;
+          phone: string | null;
           referral_code: string;
           sponsor_id: string | null;
-          right_count: number;
+          wallet_address: string | null;
+          transaction_password: string | null;
+          current_package: string;
+          is_active: boolean;
+          is_admin: boolean;
+          join_date: string;
           total_earnings: number;
           wallet_balance: number;
+          team_size: number;
+          direct_referrals: number;
           created_at: string;
           updated_at: string;
         };
         Insert: {
-          id?: string;
-          gpk_id: string;
+          id: string;
+          gpk_id?: string;
           name: string;
           email: string;
-          phone: string;
-          referral_code: string;
+          phone?: string | null;
+          referral_code?: string;
           sponsor_id?: string | null;
-          right_count?: number;
+          wallet_address?: string | null;
+          transaction_password?: string | null;
+          current_package?: string;
+          is_active?: boolean;
+          is_admin?: boolean;
+          join_date?: string;
           total_earnings?: number;
           wallet_balance?: number;
+          team_size?: number;
+          direct_referrals?: number;
         };
         Update: {
           id?: string;
           gpk_id?: string;
           name?: string;
           email?: string;
-          phone?: string;
+          phone?: string | null;
           referral_code?: string;
           sponsor_id?: string | null;
-          right_count?: number;
+          wallet_address?: string | null;
+          transaction_password?: string | null;
+          current_package?: string;
+          is_active?: boolean;
+          is_admin?: boolean;
+          join_date?: string;
           total_earnings?: number;
           wallet_balance?: number;
+          team_size?: number;
+          direct_referrals?: number;
         };
       };
       packages: {
@@ -58,9 +79,11 @@ export interface Database {
           id: string;
           name: string;
           price: number;
-          roi: number;
+          order_index: number;
+          global_royalty_eligible: boolean;
+          global_royalty_share_percent: number;
+          description: string | null;
           benefits: string[];
-          description: string;
           is_active: boolean;
           created_at: string;
           updated_at: string;
@@ -69,18 +92,49 @@ export interface Database {
           id: string;
           name: string;
           price: number;
-          roi: number;
-          benefits: string[];
-          description: string;
+          order_index: number;
+          global_royalty_eligible?: boolean;
+          global_royalty_share_percent?: number;
+          description?: string | null;
+          benefits?: string[];
           is_active?: boolean;
         };
         Update: {
           id?: string;
           name?: string;
           price?: number;
-          roi?: number;
+          order_index?: number;
+          global_royalty_eligible?: boolean;
+          global_royalty_share_percent?: number;
+          description?: string | null;
           benefits?: string[];
-          description?: string;
+          is_active?: boolean;
+        };
+      };
+      user_packages: {
+        Row: {
+          id: string;
+          user_id: string;
+          package_id: string;
+          purchase_date: string;
+          amount_paid: number;
+          is_active: boolean;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          package_id: string;
+          purchase_date?: string;
+          amount_paid: number;
+          is_active?: boolean;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          package_id?: string;
+          purchase_date?: string;
+          amount_paid?: number;
           is_active?: boolean;
         };
       };
@@ -88,49 +142,91 @@ export interface Database {
         Row: {
           id: string;
           user_id: string;
-          type: 'direct' | 'level' | 'binary' | 'royalty';
-          amount: number;
           from_user_id: string | null;
+          amount: number;
+          type: 'direct' | 'level' | 'global_royalty';
           level: number | null;
           package_id: string | null;
-          description: string;
+          description: string | null;
           date: string;
           created_at: string;
         };
         Insert: {
           id?: string;
           user_id: string;
-          type: 'direct' | 'level' | 'binary' | 'royalty';
-          amount: number;
           from_user_id?: string | null;
+          amount: number;
+          type: 'direct' | 'level' | 'global_royalty';
           level?: number | null;
           package_id?: string | null;
-          description: string;
+          description?: string | null;
           date?: string;
         };
         Update: {
           id?: string;
           user_id?: string;
-          type?: 'direct' | 'level' | 'binary' | 'royalty';
-          amount?: number;
           from_user_id?: string | null;
+          amount?: number;
+          type?: 'direct' | 'level' | 'global_royalty';
           level?: number | null;
           package_id?: string | null;
-          description?: string;
+          description?: string | null;
           date?: string;
+        };
+      };
+      referrals: {
+        Row: {
+          referrer_id: string;
+          referred_id: string;
+          referral_date: string;
+        };
+        Insert: {
+          referrer_id: string;
+          referred_id: string;
+          referral_date?: string;
+        };
+        Update: {
+          referrer_id?: string;
+          referred_id?: string;
+          referral_date?: string;
+        };
+      };
+      level_qualifications: {
+        Row: {
+          id: string;
+          user_id: string;
+          level: number;
+          qualified_at: string;
+          team_size_at_qualification: number;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          level: number;
+          qualified_at?: string;
+          team_size_at_qualification?: number;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          level?: number;
+          qualified_at?: string;
+          team_size_at_qualification?: number;
         };
       };
       transactions: {
         Row: {
           id: string;
           user_id: string;
-          type: 'deposit' | 'withdrawal' | 'upgrade';
+          type: 'deposit' | 'withdrawal' | 'package_purchase' | 'income_credit';
           amount: number;
           tx_hash: string | null;
           wallet_address: string | null;
           status: 'pending' | 'verified' | 'rejected' | 'completed';
           admin_fee: number;
           reference_id: string | null;
+          package_id: string | null;
+          description: string | null;
           date: string;
           created_at: string;
           updated_at: string;
@@ -138,67 +234,405 @@ export interface Database {
         Insert: {
           id?: string;
           user_id: string;
-          type: 'deposit' | 'withdrawal' | 'upgrade';
+          type: 'deposit' | 'withdrawal' | 'package_purchase' | 'income_credit';
           amount: number;
           tx_hash?: string | null;
           wallet_address?: string | null;
           status?: 'pending' | 'verified' | 'rejected' | 'completed';
           admin_fee?: number;
           reference_id?: string | null;
+          package_id?: string | null;
+          description?: string | null;
           date?: string;
         };
         Update: {
           id?: string;
           user_id?: string;
-          type?: 'deposit' | 'withdrawal' | 'upgrade';
+          type?: 'deposit' | 'withdrawal' | 'package_purchase' | 'income_credit';
           amount?: number;
           tx_hash?: string | null;
           wallet_address?: string | null;
           status?: 'pending' | 'verified' | 'rejected' | 'completed';
           admin_fee?: number;
           reference_id?: string | null;
+          package_id?: string | null;
+          description?: string | null;
           date?: string;
         };
       };
       admin_config: {
         Row: {
-          id: string;
-          deposit_wallet_address: string;
+          id: number;
           direct_referral_percent: number;
-          level_income_percent: number[];
-          binary_income_percent: number;
+          level_income_percents: number[];
           global_royalty_percent: number;
-          deposit_fee_percent: number;
-          withdrawal_fee_percent: number;
+          global_royalty_cycle_days: number;
+          deposit_wallet_address: string | null;
           minimum_withdrawal: number;
           minimum_deposit: number;
+          withdrawal_fee_percent: number;
+          deposit_fee_percent: number;
+          created_at: string;
           updated_at: string;
         };
         Insert: {
-          id?: string;
-          deposit_wallet_address?: string;
+          id?: number;
           direct_referral_percent?: number;
-          level_income_percent?: number[];
-          binary_income_percent?: number;
+          level_income_percents?: number[];
           global_royalty_percent?: number;
-          deposit_fee_percent?: number;
-          withdrawal_fee_percent?: number;
+          global_royalty_cycle_days?: number;
+          deposit_wallet_address?: string | null;
           minimum_withdrawal?: number;
           minimum_deposit?: number;
+          withdrawal_fee_percent?: number;
+          deposit_fee_percent?: number;
+        };
+        Update: {
+          id?: number;
+          direct_referral_percent?: number;
+          level_income_percents?: number[];
+          global_royalty_percent?: number;
+          global_royalty_cycle_days?: number;
+          deposit_wallet_address?: string | null;
+          minimum_withdrawal?: number;
+          minimum_deposit?: number;
+          withdrawal_fee_percent?: number;
+          deposit_fee_percent?: number;
+        };
+      };
+      global_royalty_distributions: {
+        Row: {
+          id: string;
+          cycle_start_date: string;
+          cycle_end_date: string;
+          total_pool_amount: number;
+          total_eligible_users: number;
+          distributed_amount: number;
+          status: 'pending' | 'distributed' | 'completed';
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          cycle_start_date: string;
+          cycle_end_date: string;
+          total_pool_amount: number;
+          total_eligible_users?: number;
+          distributed_amount?: number;
+          status?: 'pending' | 'distributed' | 'completed';
         };
         Update: {
           id?: string;
-          deposit_wallet_address?: string;
-          direct_referral_percent?: number;
-          level_income_percent?: number[];
-          binary_income_percent?: number;
-          global_royalty_percent?: number;
-          deposit_fee_percent?: number;
-          withdrawal_fee_percent?: number;
-          minimum_withdrawal?: number;
-          minimum_deposit?: number;
+          cycle_start_date?: string;
+          cycle_end_date?: string;
+          total_pool_amount?: number;
+          total_eligible_users?: number;
+          distributed_amount?: number;
+          status?: 'pending' | 'distributed' | 'completed';
+        };
+      };
+      global_royalty_payments: {
+        Row: {
+          id: string;
+          distribution_id: string;
+          user_id: string;
+          package_id: string;
+          share_percent: number;
+          amount: number;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          distribution_id: string;
+          user_id: string;
+          package_id: string;
+          share_percent: number;
+          amount: number;
+        };
+        Update: {
+          id?: string;
+          distribution_id?: string;
+          user_id?: string;
+          package_id?: string;
+          share_percent?: number;
+          amount?: number;
         };
       };
     };
+    Functions: {
+      handle_package_purchase: {
+        Args: {
+          user_id: string;
+          package_id: string;
+          amount_paid: number;
+        };
+        Returns: void;
+      };
+      get_user_level_qualification: {
+        Args: {
+          user_id: string;
+        };
+        Returns: number;
+      };
+      generate_referral_code: {
+        Args: {};
+        Returns: string;
+      };
+      generate_gpk_id: {
+        Args: {};
+        Returns: string;
+      };
+    };
   };
+}
+
+// MLM Service functions
+export class MLMService {
+  static async getPackages() {
+    const { data, error } = await supabase
+      .from('packages')
+      .select('*')
+      .eq('is_active', true)
+      .order('order_index');
+    
+    if (error) throw error;
+    return data;
+  }
+
+  static async getUserProfile(userId: string) {
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', userId)
+      .single();
+    
+    if (error) throw error;
+    return data;
+  }
+
+  static async getUserIncomes(userId: string) {
+    const { data, error } = await supabase
+      .from('incomes')
+      .select(`
+        *,
+        from_user:profiles!incomes_from_user_id_fkey(name, gpk_id),
+        package:packages(name)
+      `)
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+    
+    if (error) throw error;
+    return data;
+  }
+
+  static async getUserReferrals(userId: string) {
+    const { data, error } = await supabase
+      .from('referrals')
+      .select(`
+        *,
+        referred_user:profiles!referrals_referred_id_fkey(
+          id, name, gpk_id, current_package, join_date, is_active
+        )
+      `)
+      .eq('referrer_id', userId)
+      .order('referral_date', { ascending: false });
+    
+    if (error) throw error;
+    return data;
+  }
+
+  static async getUserPackages(userId: string) {
+    const { data, error } = await supabase
+      .from('user_packages')
+      .select(`
+        *,
+        package:packages(*)
+      `)
+      .eq('user_id', userId)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false });
+    
+    if (error) throw error;
+    return data;
+  }
+
+  static async purchasePackage(userId: string, packageId: string, amountPaid: number) {
+    const { error } = await supabase.rpc('handle_package_purchase', {
+      user_id: userId,
+      package_id: packageId,
+      amount_paid: amountPaid
+    });
+    
+    if (error) throw error;
+  }
+
+  static async createProfile(authUser: any, sponsorReferralCode?: string) {
+    // Generate unique IDs
+    const { data: gpkId } = await supabase.rpc('generate_gpk_id');
+    const { data: referralCode } = await supabase.rpc('generate_referral_code');
+    
+    let sponsorId = null;
+    
+    // Find sponsor by referral code
+    if (sponsorReferralCode) {
+      const { data: sponsor } = await supabase
+        .from('profiles')
+        .select('id')
+        .eq('referral_code', sponsorReferralCode)
+        .single();
+      
+      if (sponsor) {
+        sponsorId = sponsor.id;
+      }
+    }
+
+    // Create profile
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .insert({
+        id: authUser.id,
+        gpk_id: gpkId,
+        name: authUser.user_metadata?.full_name || authUser.email.split('@')[0],
+        email: authUser.email,
+        referral_code: referralCode,
+        sponsor_id: sponsorId,
+      })
+      .select()
+      .single();
+
+    if (profileError) throw profileError;
+
+    // Create referral relationship if there's a sponsor
+    if (sponsorId) {
+      const { error: referralError } = await supabase
+        .from('referrals')
+        .insert({
+          referrer_id: sponsorId,
+          referred_id: authUser.id
+        });
+      
+      if (referralError) throw referralError;
+    }
+
+    return profile;
+  }
+
+  static async getAdminConfig() {
+    const { data, error } = await supabase
+      .from('admin_config')
+      .select('*')
+      .limit(1)
+      .single();
+    
+    if (error) throw error;
+    return data;
+  }
+
+  static async getUserLevelQualification(userId: string) {
+    const { data, error } = await supabase.rpc('get_user_level_qualification', {
+      user_id: userId
+    });
+    
+    if (error) throw error;
+    return data;
+  }
+
+  static async getTeamStructure(userId: string, levels: number = 3) {
+    // Recursive query to get team structure
+    const { data, error } = await supabase
+      .from('profiles')
+      .select(`
+        id, name, gpk_id, current_package, join_date, total_earnings,
+        direct_referrals, team_size, is_active
+      `)
+      .eq('sponsor_id', userId);
+    
+    if (error) throw error;
+    
+    // For each direct referral, get their team if levels > 1
+    if (levels > 1 && data.length > 0) {
+      const teamData = await Promise.all(
+        data.map(async (user) => {
+          const subTeam = await this.getTeamStructure(user.id, levels - 1);
+          return { ...user, team: subTeam };
+        })
+      );
+      return teamData;
+    }
+    
+    return data;
+  }
+
+  static async getIncomesSummary(userId: string) {
+    const { data, error } = await supabase
+      .from('incomes')
+      .select('type, amount')
+      .eq('user_id', userId);
+    
+    if (error) throw error;
+    
+    const summary = {
+      total: 0,
+      direct: 0,
+      level: 0,
+      global_royalty: 0,
+      count: data.length
+    };
+    
+    data.forEach(income => {
+      summary.total += income.amount;
+      summary[income.type] += income.amount;
+    });
+    
+    return summary;
+  }
+
+  static async getTransactions(userId: string) {
+    const { data, error } = await supabase
+      .from('transactions')
+      .select(`
+        *,
+        package:packages(name)
+      `)
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+    
+    if (error) throw error;
+    return data;
+  }
+
+  static async canUpgradeToPackage(userId: string, targetPackageId: string) {
+    // Get user's current packages
+    const userPackages = await this.getUserPackages(userId);
+    const allPackages = await this.getPackages();
+    
+    // Find target package
+    const targetPackage = allPackages.find(p => p.id === targetPackageId);
+    if (!targetPackage) return { canUpgrade: false, reason: 'Package not found' };
+    
+    // Check if user already has this package
+    const hasPackage = userPackages.some(up => up.package_id === targetPackageId);
+    if (hasPackage) return { canUpgrade: false, reason: 'Already purchased' };
+    
+    // For step-by-step upgrade logic
+    const packageOrder = ['starter', 'silver', 'gold', 'platinum', 'diamond'];
+    const targetIndex = packageOrder.indexOf(targetPackageId);
+    
+    if (targetIndex === 0) {
+      // Starter package - always can purchase
+      return { canUpgrade: true };
+    }
+    
+    // Check if user has the previous package
+    const previousPackageId = packageOrder[targetIndex - 1];
+    const hasPreviousPackage = userPackages.some(up => up.package_id === previousPackageId);
+    
+    if (!hasPreviousPackage) {
+      return { 
+        canUpgrade: false, 
+        reason: `Must purchase ${previousPackageId} package first` 
+      };
+    }
+    
+    return { canUpgrade: true };
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,20 +1,22 @@
+// MLM System Types
 export interface User {
   id: string;
   gpk_id: string;
   name: string;
   email: string;
-  phone: string;
+  phone: string | null;
   referral_code: string;
   sponsor_id: string | null;
   wallet_address: string | null;
   transaction_password: string | null;
-  package_id: string | null;
+  current_package: string;
   is_active: boolean;
   is_admin: boolean;
   join_date: string;
-  right_count: number;
   total_earnings: number;
   wallet_balance: number;
+  team_size: number;
+  direct_referrals: number;
   created_at: string;
   updated_at: string;
 }
@@ -23,54 +25,126 @@ export interface Package {
   id: string;
   name: string;
   price: number;
-  roi: number;
+  order_index: number;
+  global_royalty_eligible: boolean;
+  global_royalty_share_percent: number;
+  description: string | null;
   benefits: string[];
-  description: string;
-  isActive: boolean;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UserPackage {
+  id: string;
+  user_id: string;
+  package_id: string;
+  purchase_date: string;
+  amount_paid: number;
+  is_active: boolean;
+  created_at: string;
+  package?: Package;
 }
 
 export interface Income {
   id: string;
   user_id: string;
+  from_user_id: string | null;
   amount: number;
+  type: 'direct' | 'level' | 'global_royalty';
+  level: number | null;
+  package_id: string | null;
+  description: string | null;
   date: string;
-  // Add other fields as needed
+  created_at: string;
+  from_user?: {
+    name: string;
+    gpk_id: string;
+  };
+  package?: {
+    name: string;
+  };
+}
+
+export interface Referral {
+  referrer_id: string;
+  referred_id: string;
+  referral_date: string;
+  referred_user?: {
+    id: string;
+    name: string;
+    gpk_id: string;
+    current_package: string;
+    join_date: string;
+    is_active: boolean;
+  };
 }
 
 export interface Transaction {
   id: string;
   user_id: string;
-  type: 'deposit' | 'withdrawal' | 'income' | 'upgrade';
+  type: 'deposit' | 'withdrawal' | 'package_purchase' | 'income_credit';
   amount: number;
   tx_hash: string | null;
   wallet_address: string | null;
   status: 'pending' | 'verified' | 'rejected' | 'completed';
   admin_fee: number;
   reference_id: string | null;
+  package_id: string | null;
+  description: string | null;
   date: string;
   created_at: string;
   updated_at: string;
-  description?: string;
+  package?: {
+    name: string;
+  };
 }
 
 export interface AdminConfig {
-  depositWalletAddress: string;
-  directReferralPercent: number;
-  levelIncomePercent: number[];
-  binaryIncomePercent: number;
-  globalRoyaltyPercent: number;
-  depositFeePercent: number;
-  withdrawalFeePercent: number;
-  minimumWithdrawal: number;
-  minimumDeposit: number;
-  gpkToInrPrice: number; // GPK to INR conversion rate
+  id: number;
+  direct_referral_percent: number;
+  level_income_percents: number[];
+  global_royalty_percent: number;
+  global_royalty_cycle_days: number;
+  deposit_wallet_address: string | null;
+  minimum_withdrawal: number;
+  minimum_deposit: number;
+  withdrawal_fee_percent: number;
+  deposit_fee_percent: number;
+  created_at: string;
+  updated_at: string;
 }
 
-export interface BinaryNode {
-  user: User;
+export interface LevelQualification {
+  id: string;
+  user_id: string;
   level: number;
+  qualified_at: string;
+  team_size_at_qualification: number;
 }
 
+export interface GlobalRoyaltyDistribution {
+  id: string;
+  cycle_start_date: string;
+  cycle_end_date: string;
+  total_pool_amount: number;
+  total_eligible_users: number;
+  distributed_amount: number;
+  status: 'pending' | 'distributed' | 'completed';
+  created_at: string;
+}
+
+export interface GlobalRoyaltyPayment {
+  id: string;
+  distribution_id: string;
+  user_id: string;
+  package_id: string;
+  share_percent: number;
+  amount: number;
+  created_at: string;
+}
+
+// Dashboard and UI Types
 export interface DashboardStats {
   totalUsers: number;
   activeUsers: number;
@@ -78,4 +152,63 @@ export interface DashboardStats {
   totalWithdrawals: number;
   pendingVerifications: number;
   totalEarnings: number;
+  directReferrals: number;
+  teamSize: number;
+  currentPackage: string;
+  qualifiedLevel: number;
 }
+
+export interface IncomesSummary {
+  total: number;
+  direct: number;
+  level: number;
+  global_royalty: number;
+  count: number;
+}
+
+export interface TeamMember {
+  id: string;
+  name: string;
+  gpk_id: string;
+  current_package: string;
+  join_date: string;
+  total_earnings: number;
+  direct_referrals: number;
+  team_size: number;
+  is_active: boolean;
+  team?: TeamMember[];
+}
+
+export interface PackageUpgradeCheck {
+  canUpgrade: boolean;
+  reason?: string;
+}
+
+// MLM Plan Constants
+export const PACKAGE_ORDER = ['starter', 'silver', 'gold', 'platinum', 'diamond'] as const;
+
+export const PACKAGE_PRICES = {
+  starter: 2500,
+  silver: 9500,
+  gold: 25000,
+  platinum: 95000,
+  diamond: 250000
+} as const;
+
+export const LEVEL_REQUIREMENTS = [
+  { level: 1, teamSize: 5, income: 1 },
+  { level: 2, teamSize: 25, income: 1 },
+  { level: 3, teamSize: 125, income: 1 },
+  { level: 4, teamSize: 625, income: 1 },
+  { level: 5, teamSize: 3125, income: 1 },
+  { level: 6, teamSize: 15625, income: 1 },
+  { level: 7, teamSize: 78125, income: 1 },
+  { level: 8, teamSize: 390625, income: 2 },
+  { level: 9, teamSize: 1953125, income: 3 },
+  { level: 10, teamSize: 9765625, income: 3 }
+] as const;
+
+export type PackageId = typeof PACKAGE_ORDER[number];
+export type IncomeType = 'direct' | 'level' | 'global_royalty';
+export type TransactionType = 'deposit' | 'withdrawal' | 'package_purchase' | 'income_credit';
+export type TransactionStatus = 'pending' | 'verified' | 'rejected' | 'completed';


### PR DESCRIPTION
Add initial Supabase database schemas for the MLM system.

This PR introduces the `admin_config`, `incomes`, and `referrals` tables to support the direct referral, level, and global royalty income calculations as outlined in the MLM plan.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-a766ddaf-8026-4a7e-8880-02a7e8983631) · [Cursor](https://cursor.com/background-agent?bcId=bc-a766ddaf-8026-4a7e-8880-02a7e8983631)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)